### PR TITLE
fix: negative decimal integer literal

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1,3 +1,5 @@
+/// <reference types="tree-sitter-cli/dsl" />
+
 module.exports = grammar({
   name: 'rescript',
 
@@ -1331,7 +1333,7 @@ module.exports = grammar({
       const bigint_literal = seq(choice(hex_literal, binary_literal, octal_literal, decimal_digits), 'n')
 
       const decimal_integer_literal = choice(
-        repeat('0'),
+        repeat1('0'),
         seq(repeat('0'), /[1-9]/, optional(seq(optional('_'), decimal_digits)))
       )
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1149,6 +1149,8 @@ Math operators
 - 1 + 2 / 3
 -. 1.0 +. 2.0 /. 3.0
 2.0 ** 3.0
+-0l
+-ln
 
 --------------------------------------------------------------------------------
 
@@ -1170,7 +1172,12 @@ Math operators
   (expression_statement
     (binary_expression
       (number)
-      (number))))
+      (number)))
+  (expression_statement
+    (number))
+  (expression_statement
+    (unary_expression
+      (value_identifier))))
 
 ================================================================================
 Boolean operators


### PR DESCRIPTION
This fixes a bug that I found while trying to parse unary negation operations like `-ln` and `-lSum`:  
![image](https://github.com/nkrkv/tree-sitter-rescript/assets/4299733/d87d4584-a9ce-42f7-b268-297f7218e156)
  
And this is the problematic node:  
![image](https://github.com/nkrkv/tree-sitter-rescript/assets/4299733/dcf5c49b-6533-4f39-a9bb-1be71db5b938)
