### PR TITLE
fix: comment before `else` and `and`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -451,7 +451,7 @@ module.exports = grammar({
       choice('export', 'let'),
       optional('rec'),
       sep1(
-        seq(repeat($._newline), 'and'),
+        seq(repeat($._newline_and_comment), 'and'),
         $.let_binding
       )
     ),

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -243,6 +243,18 @@ bool tree_sitter_rescript_external_scanner_scan(
           in_multiline_statement = true;
         }
       }
+    } else if (lexer->lookahead == 'e') {
+      advance(lexer);
+      if (lexer->lookahead == 'l') {
+        advance(lexer);
+        if (lexer->lookahead == 's') {
+          advance(lexer);
+          if (lexer->lookahead == 'e') {
+            // Ignore new lines before `else` keyword
+            in_multiline_statement = true;
+          }
+        }
+      }
     }
 
     if (in_multiline_statement) {

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -37,6 +37,19 @@ switch foo {
 // in-switch
 }
 
+if predicate {
+  foo
+} /* comment */
+else {
+  bar
+}
+
+/* comment */
+let foo = 1
+/* comment */
+@baz
+and bar = 2
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -80,4 +93,25 @@ switch foo {
         (sequence_expression
           (expression_statement
             (number))))
-      (comment))))
+      (comment)))
+  (expression_statement
+    (if_expression
+      (value_identifier)
+      (block
+        (expression_statement
+          (value_identifier)))
+      (comment)
+      (else_clause
+        (block
+          (expression_statement
+            (value_identifier))))))
+  (comment)
+  (let_declaration
+    (let_binding
+      (value_identifier)
+      (number))
+    (decorator
+      (decorator_identifier))
+    (let_binding
+      (value_identifier)
+      (number))))


### PR DESCRIPTION
This fixes errors when parsing comments and newlines before `else` clauses and decorated `and` bindings.