### PR TITLE
Fix all injections and add support for rescript-relay

### DIFF
--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -19,3 +19,11 @@
   (#eq? @_name "graphql")
   (expression_statement
     (_ (_) @injection.content (#set! injection.language "graphql"))))
+
+; %relay
+(extension_expression
+  (extension_identifier) @_name
+  (#eq? @_name "relay")
+  (expression_statement
+    (_ (_) @injection.content (#set! injection.language "graphql") )))
+

--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,21 +1,21 @@
-(comment) @comment
+((comment) @injection.content (#set! injection.language "comment"))
 
 ; %re
 (extension_expression
   (extension_identifier) @_name
   (#eq? @_name "re")
-  (expression_statement (_) @regex))
+  (expression_statement (_) @injection.content (#set! injection.language "regex")))
 
 ; %raw
 (extension_expression
   (extension_identifier) @_name
   (#eq? @_name "raw")
   (expression_statement
-    (_ (_) @javascript)))
+    (_ (_)  @injection.content (#set! injection.language "javascript"))))
 
 ; %graphql
 (extension_expression
   (extension_identifier) @_name
   (#eq? @_name "graphql")
   (expression_statement
-    (_ (_) @graphql)))
+    (_ (_) @injection.content (#set! injection.language "graphql"))))


### PR DESCRIPTION
It's been some time since Neovim switched to the [official](https://tree-sitter.github.io/tree-sitter/syntax-highlighting#language-injection) Tree-sitter syntax for injections. 

This PR fixes all the injections so they work with recent versions of Neovim, and also adds support for GraphQL syntax highlighting in [`rescript-relay`](https://rescript-relay-documentation.vercel.app/docs/getting-started). 