### PR TITLE
update tree-sitter-cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ wild_sandboxes := $(patsubst %,test_wild/%,$(wild_github_repos))
 
 .PHONY: generate
 generate: binding.gyp
-	$(TS) generate
+	$(TS) generate --no-bindings
 
 binding.gyp: binding.gyp.json
 	cp $< $@

--- a/grammar.js
+++ b/grammar.js
@@ -81,7 +81,6 @@ module.exports = grammar({
     [$.primary_expression, $.record_pattern],
     [$.primary_expression, $.spread_pattern],
     [$.primary_expression, $._literal_pattern],
-    [$.primary_expression, $.lazy_pattern],
     [$.primary_expression, $._jsx_child],
     [$.tuple_type, $.function_type_parameter],
     [$.list, $.list_pattern],
@@ -108,7 +107,6 @@ module.exports = grammar({
     [$.exception_pattern, $.or_pattern],
     [$.type_binding, $._inline_type],
     [$._module_structure, $.parenthesized_module_expression],
-    [$.record_type_field, $.object_type_field],
     [$._record_type_member, $._object_type_member],
   ],
 
@@ -1415,7 +1413,7 @@ module.exports = grammar({
         /[0-7]{1,3}/,
         /x[0-9a-fA-F]{2}/,
         /u[0-9a-fA-F]{4}/,
-        /u{[0-9a-fA-F]+}/
+        /u\{[0-9a-fA-F]+\}/
       )
     )),
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "nan": "^2.15.0"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.20.8"
+    "tree-sitter-cli": "^0.22.2"
   },
   "tree-sitter": [
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,7 +7,7 @@ nan@^2.15.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
   integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
 
-tree-sitter-cli@^0.20.8:
-  version "0.20.8"
-  resolved "https://registry.yarnpkg.com/tree-sitter-cli/-/tree-sitter-cli-0.20.8.tgz#06a81cea8d6d82f93d67eed7d28b6bc04a4a8916"
-  integrity sha512-XjTcS3wdTy/2cc/ptMLc/WRyOLECRYcMTrSWyhZnj1oGSOWbHLTklgsgRICU3cPfb0vy+oZCC33M43u6R1HSCA==
+tree-sitter-cli@^0.22.2:
+  version "0.22.2"
+  resolved "https://registry.yarnpkg.com/tree-sitter-cli/-/tree-sitter-cli-0.22.2.tgz#a69b8f68e78994f6ab730e7b345407b880658c13"
+  integrity sha512-ecqccEp27XMFXgjLMEEU71vK9JCWAC7fqSTTxcs5P1tnEnaaf4GkHz/wfo4lJ9l3rfxcTDPxN84tHAoitIQqdA==


### PR DESCRIPTION
Tree-sitter now show unnecessary conflicts:

```
Warning: unnecessary conflicts
  `record_type_field`, `object_type_field`
  `primary_expression`, `lazy_pattern`
```

Close #242 