### PR TITLE
fix: remove redundant `seq` call

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1364,7 +1364,7 @@ module.exports = grammar({
           seq(decimal_integer_literal, '.', optional(decimal_digits), optional(exponent_part)),
           seq('.', decimal_digits, optional(exponent_part)),
           seq(decimal_integer_literal, exponent_part),
-          seq(decimal_digits),
+          decimal_digits,
         )
       )
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7621,13 +7621,8 @@
                     ]
                   },
                   {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\d(_?\\d)*"
-                      }
-                    ]
+                    "type": "PATTERN",
+                    "value": "\\d(_?\\d)*"
                   }
                 ]
               }


### PR DESCRIPTION
This doesn't change the grammar at all, just cleans it up a bit per the error message given when running `tree-sitter g` on the current build (with HEAD CLI version).

See https://github.com/nvim-treesitter/nvim-treesitter/pull/6671#issuecomment-2250047437